### PR TITLE
1.This change ensures that the arguments 'a' and 'b' are only evaluat…

### DIFF
--- a/src/core/configuration.c
+++ b/src/core/configuration.c
@@ -18,7 +18,12 @@
 #endif
 
 #if !defined(MIN)
-#define MIN(a, b)			(((a) > (b))? (b) : (a))
+#define MIN(a, b) ({          \
+    __typeof__(a) _a = (a);   \
+    __typeof__(b) _b = (b);   \
+    _a > _b ? _b : _a;        \
+})
+
 #endif
 
 #define CONF_SIZE(x)			(x)


### PR DESCRIPTION
Refactor MIN macro to avoid multiple evaluations

Replaced the old MIN macro definition:

#define MIN(a, b) (((a) > (b)) ? (b) : (a))

with a new version that uses temporary variables:

#define MIN(a, b) ({ \
    __typeof__(a) _a = (a); \
    __typeof__(b) _b = (b); \
    _a > _b ? _b : _a; \
})

This change ensures that the arguments 'a' and 'b' are only evaluated once, preventing potential side effects from multiple evaluations.
