### PR TITLE
1._Static_assert is a syntax in C11, write STATIC_ASSERT to be compat…

### DIFF
--- a/src/core/configuration.c
+++ b/src/core/configuration.c
@@ -50,7 +50,9 @@ static const char * const confstr[] = {
 #include OCPP_CONFIGURATION_DEFINES
 #undef OCPP_CONFIG
 };
-_Static_assert(sizeof(confstr) / sizeof(confstr[0]) == CONFIGURATION_MAX, "");
+
+#define STATIC_ASSERT(expr, msg) typedef char STATIC_ASSERTION__##msg[(expr) ? 1 : -1]
+STATIC_ASSERT(sizeof(confstr) / sizeof(confstr[0]) == CONFIGURATION_MAX, __failed);
 
 static ocpp_configuration_data_t get_value_type(configuration_t key)
 {


### PR DESCRIPTION
1._Static_assert is a syntax in C11, write STATIC_ASSERT to be compat…