### PR TITLE
feat(ocpp): add force push option to ocpp_push_request

### DIFF
--- a/examples/messages.c
+++ b/examples/messages.c
@@ -15,7 +15,7 @@ int ocpp_send_bootnotification(const struct ocpp_BootNotification *msg)
 		return -EINVAL;
 	}
 
-	return ocpp_push_request(OCPP_MSG_BOOTNOTIFICATION, msg, sizeof(*msg));
+	return ocpp_push_request(OCPP_MSG_BOOTNOTIFICATION, msg, sizeof(*msg), false);
 }
 
 int ocpp_send_datatransfer(const struct ocpp_DataTransfer *msg)
@@ -24,5 +24,5 @@ int ocpp_send_datatransfer(const struct ocpp_DataTransfer *msg)
 		return -EINVAL;
 	}
 
-	return ocpp_push_request(OCPP_MSG_DATA_TRANSFER, msg, sizeof(*msg));
+	return ocpp_push_request(OCPP_MSG_DATA_TRANSFER, msg, sizeof(*msg), false);
 }

--- a/include/ocpp/ocpp.h
+++ b/include/ocpp/ocpp.h
@@ -54,7 +54,24 @@ struct ocpp_message {
 
 int ocpp_init(ocpp_event_callback_t cb, void *cb_ctx);
 int ocpp_step(void);
-int ocpp_push_request(ocpp_message_t type, const void *data, size_t datasize);
+/**
+ * @bref Function to push a request to the OCPP server.
+ *
+ * @param[in] type The type of the OCPP message.
+ * @param[in] data Pointer to the data to be sent.
+ * @param[in] datasize The size of the data to be sent.
+ * @param[in] force If set to true, the request will be pushed even if the queue
+ *            is full.
+ *
+ * @note The oldest request will be dropped if the queue is full and `force` is
+ *       set. If the oldest request is StartTransaction, StopTransaction or
+ *       BootNotification, the next oldest request will be dropped.
+ *
+ * @return Returns 0 if the request was successfully pushed, non-zero
+ *         otherwise.
+ */
+int ocpp_push_request(ocpp_message_t type, const void *data, size_t datasize,
+		bool force);
 int ocpp_push_request_defer(ocpp_message_t type,
 		const void *data, size_t datasize, uint32_t timer_sec);
 int ocpp_push_response(const struct ocpp_message *req,

--- a/tests/runners/core.mk
+++ b/tests/runners/core.mk
@@ -5,6 +5,7 @@ COMPONENT_NAME = Core
 SRC_FILES = \
 	../src/ocpp.c \
 	../src/core/configuration.c \
+	../examples/messages.c \
 
 TEST_SRC_FILES = \
 	src/core_test.cpp \


### PR DESCRIPTION
This commit introduces a new parameter to the `ocpp_push_request` function that allows forcing a request to be pushed even if the queue is full. If the queue is full and the force option is set, the oldest request will be dropped to make room for the new one. However, if the oldest request is StartTransaction, StopTransaction or BootNotification, the next oldest request will be dropped, which means those messages never get dropped. This feature is useful in situations where it's critical to send a new request regardless of the queue state.

BREAKING CHANGE: The `ocpp_push_request` function now requires an additional boolean parameter. Existing calls to this function will need to be updated.