### PR TITLE
Add boot notification acceptance handling

### DIFF
--- a/tests/src/configuration_test.cpp
+++ b/tests/src/configuration_test.cpp
@@ -24,7 +24,7 @@ TEST_GROUP(Configuration) {
 
 TEST(Configuration, reset_ShouldSetTheDefaultValues) {
 	int connTimeout;
-	int authRemoteTxReq;
+	bool authRemoteTxReq;
 	int blink;
 
 	ocpp_get_configuration("ConnectionTimeOut", &connTimeout, sizeof(connTimeout), NULL);


### PR DESCRIPTION
This pull request introduces several changes to the `src/ocpp.c` file, primarily focusing on adding a new boot acceptance mechanism and improving logging. Additionally, there are updates to the test files to accommodate these changes. The most important changes include adding new functions for boot acceptance, updating the message processing logic, and modifying the tests accordingly.

### Boot Acceptance Mechanism:

* Added a new boolean member `boot_accepted` to the `struct` in `src/ocpp.c` to track boot acceptance status.
* Introduced `is_boot_accepted` and `set_boot_accepted` functions to check and set the boot acceptance status.
* Updated `should_send_heartbeat` function to include a check for boot acceptance status.

### Message Processing:

* Refactored `process_central_response` to handle boot notification responses and set boot acceptance status.
* Simplified the logic in `process_incoming_messages` by delegating response processing to `process_central_response`.

### Logging Improvements:

* Replaced `info` logging calls with `OCPP_DEBUG` in various message handling functions to standardize debug logging.

### Testing Updates:

* Modified tests in `configuration_test.cpp` and `core_test.cpp` to use the new boot acceptance mechanism and ensure proper functionality. [[1]](diffhunk://#diff-73d9b38aab9b657e78c7c72bb3c7d3a4d08a8ff2a0c2f92484706f3c35c43563L27-R27) [[2]](diffhunk://#diff-6b1943a70d29bb7eefa8a7ecd89c44c3b01214d6fb2d87c6308b66dac9317405L36-R38) [[3]](diffhunk://#diff-6b1943a70d29bb7eefa8a7ecd89c44c3b01214d6fb2d87c6308b66dac9317405R76) [[4]](diffhunk://#diff-6b1943a70d29bb7eefa8a7ecd89c44c3b01214d6fb2d87c6308b66dac9317405R96-R117) [[5]](diffhunk://#diff-6b1943a70d29bb7eefa8a7ecd89c44c3b01214d6fb2d87c6308b66dac9317405R152-R161)