### PR TITLE
Add ENOTSUP error handling in process_incoming_messages

### DIFF
--- a/include/ocpp/overrides.h
+++ b/include/ocpp/overrides.h
@@ -30,6 +30,10 @@ int ocpp_send(const struct ocpp_message *msg);
  * This function receives an OCPP message from the server. The received message
  * is stored in the provided ocpp_message structure.
  *
+ * If the function returns -ENOTSUP, it sends an error response message. In the
+ * case of an ENOTSUP error, the last received message time is recorded. For
+ * other errors, the time is not recorded.
+ *
  * @param[out] msg A pointer to the ocpp_message structure where the received
  *             message will be stored.
  * @return An integer indicating the status of the operation. A return value


### PR DESCRIPTION
This pull request introduces changes to the OCPP message handling in the `ocpp` module. The main improvements include handling of `ENOTSUP` errors, refactoring the `push_message` function, and updating the message processing logic to account for these changes.

Error handling improvements:
* [`include/ocpp/overrides.h`](diffhunk://#diff-4ed607872b25bc4e52797b5f8beea6bc0ad1469c3461aa85c43baf111caa7060R33-R36): Updated the `ocpp_send` function to handle `ENOTSUP` errors by sending an error response message and recording the last received message time.

Refactoring and message processing:
* [`src/ocpp.c`](diffhunk://#diff-eba7bf82e208cb35c2a746e48ef277383447b7724e6c53a58347fb0fcc88ac32R234-R251): Added a new `push_message` function to handle message creation and insertion into a list. This function is now used in the message processing logic.
* [`src/ocpp.c`](diffhunk://#diff-eba7bf82e208cb35c2a746e48ef277383447b7724e6c53a58347fb0fcc88ac32L538-R566): Modified the `process_incoming_messages` function to handle `ENOTSUP` errors by pushing an error message and updating the last received timestamp.