### PR TITLE
Add stringify functions for OCPP statuses and errors

### DIFF
--- a/build.cmake
+++ b/build.cmake
@@ -3,5 +3,6 @@
 list(APPEND OCPP_SRCS
 	${CMAKE_CURRENT_LIST_DIR}/src/ocpp.c
 	${CMAKE_CURRENT_LIST_DIR}/src/core/configuration.c
+	${CMAKE_CURRENT_LIST_DIR}/src/stringify.c
 )
 list(APPEND OCPP_INCS ${CMAKE_CURRENT_LIST_DIR}/include)

--- a/build.mk
+++ b/build.mk
@@ -7,5 +7,6 @@ endif
 OCPP_SRCS := \
 	$(ocpp-basedir)src/ocpp.c \
 	$(ocpp-basedir)src/core/configuration.c \
+	$(ocpp-basedir)src/stringify.c \
 
 OCPP_INCS := $(ocpp-basedir)include

--- a/include/ocpp/stringify.h
+++ b/include/ocpp/stringify.h
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef LIBMCU_OCPP_STRINGIFY_H
+#define LIBMCU_OCPP_STRINGIFY_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#include "ocpp/type.h"
+
+const char *ocpp_stringify_fw_update_status(ocpp_comm_status_t status);
+const char *ocpp_stringify_error(ocpp_error_t err);
+const char *ocpp_stringify_status(ocpp_status_t status);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* LIBMCU_OCPP_STRINGIFY_H */

--- a/src/stringify.c
+++ b/src/stringify.c
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "ocpp/type.h"
+
+const char *ocpp_stringify_fw_update_status(ocpp_comm_status_t status) {
+	const char *tbl[] = {
+		[OCPP_COMM_IDLE] = "Idle",
+		[OCPP_COMM_UPLOADED] = "Uploaded",
+		[OCPP_COMM_UPLOAD_FAILED] = "UploadFailed",
+		[OCPP_COMM_UPLOADING] = "Uploading",
+		[OCPP_COMM_DOWNLOADED] = "Downloaded",
+		[OCPP_COMM_DOWNLOAD_FAILED] = "DownloadFailed",
+		[OCPP_COMM_DOWNLOADING] = "Downloading",
+		[OCPP_COMM_INSTALLATION_FAILED] = "InstallationFailed",
+		[OCPP_COMM_INSTALLING] = "Installing",
+		[OCPP_COMM_INSTALLED] = "Installed",
+	};
+
+	return tbl[status];
+}
+
+const char *ocpp_stringify_error(ocpp_error_t err)
+{
+	const char *tbl[] = {
+		[OCPP_ERROR_NONE] = "NoError",
+		[OCPP_ERROR_CONNECTOR_LOCK_FAILURE] = "ConnectorLockFailure",
+		[OCPP_ERROR_EV_COMMUNICATION] = "EVCommunicationError",
+		[OCPP_ERROR_GROUND] = "GroundFailure",
+		[OCPP_ERROR_HIGH_TEMPERATURE] = "HighTemperature",
+		[OCPP_ERROR_INTERNAL] = "InternalError",
+		[OCPP_ERROR_LOCAL_LIST_CONFLICT] = "LocalListConflict",
+		[OCPP_ERROR_OTHER] = "OtherError",
+		[OCPP_ERROR_OVER_CURRENT] = "OverCurrentFailure",
+		[OCPP_ERROR_OVER_VOLTAGE] = "OverVoltage",
+		[OCPP_ERROR_POWER_METER] = "PowerMeterFailure",
+		[OCPP_ERROR_POWER_SWITCH] = "PowerSwitchFailure",
+		[OCPP_ERROR_READER] = "ReaderFailure",
+		[OCPP_ERROR_RESET] = "ResetFailure",
+		[OCPP_ERROR_UNDER_VOLTAGE] = "UnderVoltage",
+		[OCPP_ERROR_WEAK_SIGNAL] = "WeakSignal",
+	};
+
+	return tbl[err];
+}
+
+const char *ocpp_stringify_status(ocpp_status_t status)
+{
+	const char *tbl[] = {
+		[OCPP_STATUS_AVAILABLE] = "Available",
+		[OCPP_STATUS_PREPARING] = "Preparing",
+		[OCPP_STATUS_CHARGING] = "Charging",
+		[OCPP_STATUS_SUSPENDED_EVSE] = "SuspendedEVSE",
+		[OCPP_STATUS_SUSPENDED_EV] = "SuspendedEV",
+		[OCPP_STATUS_FINISHING] = "Finishing",
+		[OCPP_STATUS_RESERVED] = "Reserved",
+		[OCPP_STATUS_UNAVAILABLE] = "Unavailable",
+		[OCPP_STATUS_FAULTED] = "Faulted",
+	};
+
+	return tbl[status];
+}


### PR DESCRIPTION
This pull request introduces a new `stringify` module for converting various OCPP statuses and errors to their string representations and includes several related changes across multiple files. The most important changes are listed below:

### New `stringify` module:

* [`include/ocpp/stringify.h`](diffhunk://#diff-559c85afde7ed634d7b68e22bdc168fe20eef39112057aa682043c63702bdeb6R1-R24): Added a new header file defining functions for converting OCPP statuses and errors to strings.
* [`src/stringify.c`](diffhunk://#diff-ed5ad0e74f6a8b9365337a74f08bed038541dc8c51b3b023cd09e6cce1ec87f9R1-R65): Implemented the functions defined in `stringify.h` to return string representations of firmware update statuses, errors, and general statuses.

### Build system updates:

* [`build.cmake`](diffhunk://#diff-7120449a000055118cc47552689e386c2144e01f2e963b3102bb21a3675cd191R6): Added `stringify.c` to the list of source files to be compiled.
* [`build.mk`](diffhunk://#diff-dddca1fe0541b04ac2266bbeb174fd9dd6b56f97ad72a3fe1907e15a5de9d3e0R10): Added `stringify.c` to the list of source files to be compiled.

### Code improvements:

* [`src/ocpp.c`](diffhunk://#diff-eba7bf82e208cb35c2a746e48ef277383447b7724e6c53a58347fb0fcc88ac32L537-R537): Improved error handling in the `process_incoming_messages` function to handle `-ENOTSUP` errors more gracefully and push messages appropriately. [[1]](diffhunk://#diff-eba7bf82e208cb35c2a746e48ef277383447b7724e6c53a58347fb0fcc88ac32L537-R537) [[2]](diffhunk://#diff-eba7bf82e208cb35c2a746e48ef277383447b7724e6c53a58347fb0fcc88ac32L555-R563)