### PR TITLE
BREAKING: change ocpp_push_request() prototype.

### DIFF
--- a/include/ocpp/ocpp.h
+++ b/include/ocpp/ocpp.h
@@ -80,23 +80,44 @@ int ocpp_init(ocpp_event_callback_t cb, void *cb_ctx);
 int ocpp_step(void);
 
 /**
- * @bref Function to push a request to the OCPP server.
+ * @brief Pushes an OCPP request message.
  *
- * @param[in] type The type of the OCPP message.
- * @param[in] data Pointer to the data to be sent.
- * @param[in] datasize The size of the data to be sent.
- * @param[in] force If set to true, the request will be pushed even if the queue
- *            is full.
+ * This function creates and pushes an OCPP request message of the specified
+ * type.
  *
- * @note The oldest request will be dropped if the queue is full and `force` is
- *       set. If the oldest request is StartTransaction, StopTransaction or
- *       BootNotification, the next oldest request will be dropped.
+ * @param[in] type The type of the OCPP message to be pushed.
+ * @param[in] data A pointer to the data to be included in the message.
+ * @param[in] datasize The size of the data to be included in the message.
+ * @param[out] created A pointer to a pointer to an ocpp_message structure
+ *             where the created message will be stored.
  *
  * @return Returns 0 if the request was successfully pushed, non-zero
  *         otherwise.
  */
 int ocpp_push_request(ocpp_message_t type, const void *data, size_t datasize,
-		bool force);
+		struct ocpp_message **created);
+
+/**
+ * @brief Pushes an OCPP request message forcefully.
+ *
+ * This function creates and pushes an OCPP request message of the specified
+ * type, ensuring that the message is pushed even if the queue is full.
+ *
+ * @note The oldest request will be dropped if the queue is full set. If the
+ *       oldest request is StartTransaction, StopTransaction or
+ *       BootNotification, the next oldest request will be dropped.
+ *
+ * @param[in] type The type of the OCPP message to be pushed.
+ * @param[in] data A pointer to the data to be included in the message.
+ * @param[in] datasize The size of the data to be included in the message.
+ * @param[out] created A pointer to a pointer to an ocpp_message structure
+ *             where the created message will be stored.
+ *
+ * @return Returns 0 if the request was successfully pushed, non-zero
+ *         otherwise.
+ */
+int ocpp_push_request_force(ocpp_message_t type, const void *data,
+		size_t datasize, struct ocpp_message **created);
 
 /**
  * @brief Pushes a deferred OCPP request.

--- a/include/ocpp/ocpp.h
+++ b/include/ocpp/ocpp.h
@@ -164,32 +164,24 @@ int ocpp_push_response(const struct ocpp_message *req,
 size_t ocpp_count_pending_requests(void);
 
 /**
- * @brief Save the current OCPP context as a snapshot.
+ * @brief Converts an OCPP message type to its string representation.
  *
- * @param[out] buf buffer for the snapshot to be saved
- * @param[in] bufsize size of the buffer
+ * @param[in] msgtype The OCPP message type to be converted.
  *
- * @note A header is included in the snapshot for validation upon restore,
- *       which is processed internally.
- *
- * @return 0 for success, otherwise an error.
+ * @return A constant character pointer to the string representation of the
+ * message type.
  */
-int ocpp_save_snapshot(void *buf, size_t bufsize);
-/**
- * @brief Restore the OCPP context from a snapshot.
- *
- * @param[in] snapshot snapshot to be loaded
- *
- * @note No need to call `ocpp_init()` when this function is used.
- *
- * @return 0 for success, otherwise an error.
- */
-int ocpp_restore_snapshot(const void *snapshot);
-size_t ocpp_compute_snapshot_size(void);
-
 const char *ocpp_stringify_type(ocpp_message_t msgtype);
 
+/**
+ * @brief Get message type from message type string
+ *
+ * @param[in] typestr The string representation of the OCPP message type.
+ *
+ * @return Type of message. `OCPP_MSG_MAX` if no matching found.
+ */
 ocpp_message_t ocpp_get_type_from_string(const char *typestr);
+
 /**
  * @brief Get message type from ID string
  *

--- a/include/ocpp/stringify.h
+++ b/include/ocpp/stringify.h
@@ -16,6 +16,14 @@ extern "C" {
 const char *ocpp_stringify_fw_update_status(ocpp_comm_status_t status);
 const char *ocpp_stringify_error(ocpp_error_t err);
 const char *ocpp_stringify_status(ocpp_status_t status);
+const char *ocpp_stringify_availability_status(ocpp_availability_status_t status);
+const char *ocpp_stringify_config_status(ocpp_config_status_t status);
+const char *ocpp_stringify_data_status(ocpp_data_status_t status);
+const char *ocpp_stringify_profile_status(ocpp_profile_status_t status);
+const char *ocpp_stringify_remote_status(ocpp_remote_status_t status);
+const char *ocpp_stringify_reservation_status(ocpp_reservation_status_t status);
+const char *ocpp_stringify_trigger_status(ocpp_trigger_status_t status);
+const char *ocpp_stringify_stop_reason(ocpp_stop_reason_t reason);
 
 #if defined(__cplusplus)
 }

--- a/include/ocpp/type.h
+++ b/include/ocpp/type.h
@@ -380,19 +380,19 @@ typedef enum {
 } ocpp_log_t;
 
 struct ocpp_KeyValue {
-	char key[50+1];
+	char key[OCPP_CiString50];
 	bool readonly;
-	char value[500+1];
+	char value[OCPP_CiString500];
 };
 
 struct ocpp_idTagInfo {
 	time_t expiryDate;
-	char parentIdTag[20+1];
+	char parentIdTag[OCPP_CiString20];
 	ocpp_auth_status_t status;
 };
 
 struct ocpp_AuthorizationData {
-	char idTag[20+1];
+	char idTag[OCPP_CiString20];
 	struct ocpp_idTagInfo idTagInfo;
 };
 

--- a/src/stringify.c
+++ b/src/stringify.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include "ocpp/type.h"
+#include "ocpp/stringify.h"
 
 const char *ocpp_stringify_fw_update_status(ocpp_comm_status_t status) {
 	const char *tbl[] = {
@@ -62,4 +62,104 @@ const char *ocpp_stringify_status(ocpp_status_t status)
 	};
 
 	return tbl[status];
+}
+
+const char *ocpp_stringify_availability_status(ocpp_availability_status_t status)
+{
+	const char *tbl[] = {
+		[OCPP_AVAILABILITY_STATUS_ACCEPTED] = "Accepted",
+		[OCPP_AVAILABILITY_STATUS_REJECTED] = "Rejected",
+		[OCPP_AVAILABILITY_STATUS_SCHEDULED] = "Scheduled",
+	};
+
+	return tbl[status];
+}
+
+const char *ocpp_stringify_config_status(ocpp_config_status_t status)
+{
+	const char *tbl[] = {
+		[OCPP_CONFIG_STATUS_ACCEPTED] = "Accepted",
+		[OCPP_CONFIG_STATUS_REJECTED] = "Rejected",
+		[OCPP_CONFIG_STATUS_REBOOT_REQUIRED] = "RebootRequired",
+		[OCPP_CONFIG_STATUS_NOT_SUPPORTED] = "NotSupported",
+	};
+
+	return tbl[status];
+}
+
+const char *ocpp_stringify_data_status(ocpp_data_status_t status)
+{
+	const char *tbl[] = {
+		[OCPP_DATA_STATUS_ACCEPTED] = "Accepted",
+		[OCPP_DATA_STATUS_REJECTED] = "Rejected",
+		[OCPP_DATA_STATUS_UNKNOWN_VENDOR_ID] = "UnknownVendorId",
+		[OCPP_DATA_STATUS_UNKNOWN_MESSAGE_ID] = "UnknownMessageId",
+	};
+
+	return tbl[status];
+}
+
+const char *ocpp_stringify_profile_status(ocpp_profile_status_t status)
+{
+	const char *tbl[] = {
+		[OCPP_PROFILE_STATUS_ACCEPTED] = "Accepted",
+		[OCPP_PROFILE_STATUS_REJECTED] = "Rejected",
+		[OCPP_PROFILE_STATUS_NOT_SUPPORTED] = "NotSupported",
+		[OCPP_PROFILE_STATUS_UNKNOWN] = "Unknown",
+	};
+
+	return tbl[status];
+}
+
+const char *ocpp_stringify_remote_status(ocpp_remote_status_t status)
+{
+	const char *tbl[] = {
+		[OCPP_REMOTE_STATUS_ACCEPTED] = "Accepted",
+		[OCPP_REMOTE_STATUS_REJECTED] = "Rejected",
+	};
+
+	return tbl[status];
+}
+
+const char *ocpp_stringify_reservation_status(ocpp_reservation_status_t status)
+{
+	const char *tbl[] = {
+		[OCPP_RESERVE_STATUS_ACCEPTED] = "Accepted",
+		[OCPP_RESERVE_STATUS_FAULTED] = "Faulted",
+		[OCPP_RESERVE_STATUS_OCCUPIED] = "Occupied",
+		[OCPP_RESERVE_STATUS_REJECTED] = "Rejected",
+		[OCPP_RESERVE_STATUS_UNAVAILABLE] = "Unavailable",
+	};
+
+	return tbl[status];
+}
+
+const char *ocpp_stringify_trigger_status(ocpp_trigger_status_t status)
+{
+	const char *tbl[] = {
+		[OCPP_TRIGGER_STATUS_ACCEPTED] = "Accepted",
+		[OCPP_TRIGGER_STATUS_REJECTED] = "Rejected",
+		[OCPP_TRIGGER_STATUS_NOT_IMPLEMENTED] = "NotImplemented",
+	};
+
+	return tbl[status];
+}
+
+const char *ocpp_stringify_stop_reason(ocpp_stop_reason_t reason)
+{
+	const char *tbl[] = {
+		[OCPP_STOP_REASON_LOCAL] = "Local",
+		[OCPP_STOP_REASON_DEAUTHORIZED] = "DeAuthorized",
+		[OCPP_STOP_REASON_EMERGENCY_STOP] = "EmergencyStop",
+		[OCPP_STOP_REASON_EV_DISCONNECTED] = "EVDisconnected",
+		[OCPP_STOP_REASON_HARD_RESET] = "HardReset",
+		[OCPP_STOP_REASON_OTHER] = "Other",
+		[OCPP_STOP_REASON_POWER_LOSS] = "PowerLoss",
+		[OCPP_STOP_REASON_REBOOT] = "Reboot",
+		[OCPP_STOP_REASON_REMOTE] = "Remote",
+		[OCPP_STOP_REASON_SOFT_RESET] = "SoftReset",
+		[OCPP_STOP_REASON_UNLOCK_COMMAND] = "UnlockCommand",
+	};
+
+	return tbl[reason];
 }

--- a/tests/src/core_test.cpp
+++ b/tests/src/core_test.cpp
@@ -215,12 +215,12 @@ TEST(Core, ShouldSendStartTransaction_WhenQueueIsFull) {
 	struct ocpp_DataTransfer msg[8];
 	struct ocpp_StartTransaction start;
 	for (int i = 0; i < 8; i++) {
-		LONGS_EQUAL(0, ocpp_push_request(OCPP_MSG_DATA_TRANSFER, &msg[i], sizeof(msg[i]), false));
+		LONGS_EQUAL(0, ocpp_push_request(OCPP_MSG_DATA_TRANSFER, &msg[i], sizeof(msg[i]), NULL));
 	}
 
-	LONGS_EQUAL(-ENOMEM, ocpp_push_request(OCPP_MSG_START_TRANSACTION, &start, sizeof(start), false));
+	LONGS_EQUAL(-ENOMEM, ocpp_push_request(OCPP_MSG_START_TRANSACTION, &start, sizeof(start), NULL));
 	mock().expectOneCall("on_ocpp_event").withParameter("event_type", OCPP_EVENT_MESSAGE_FREE);
-	LONGS_EQUAL(0, ocpp_push_request(OCPP_MSG_START_TRANSACTION, &start, sizeof(start), true));
+	LONGS_EQUAL(0, ocpp_push_request_force(OCPP_MSG_START_TRANSACTION, &start, sizeof(start), NULL));
 
 	mock().expectNCalls(6, "on_ocpp_event").withParameter("event_type", OCPP_EVENT_MESSAGE_FREE);
 	for (int i = 0; i < 7*OCPP_DEFAULT_TX_RETRIES; i++) {
@@ -246,13 +246,13 @@ TEST(Core, ShouldReturnNOMEM_WhenQueueIsFullWithTransactionRelatedMessages) {
 	struct ocpp_DataTransfer data;
 	struct ocpp_StartTransaction start;
 	for (int i = 0; i < 8; i++) {
-		LONGS_EQUAL(0, ocpp_push_request(OCPP_MSG_DATA_TRANSFER, &data, sizeof(data), false));
+		LONGS_EQUAL(0, ocpp_push_request(OCPP_MSG_DATA_TRANSFER, &data, sizeof(data), NULL));
 	}
 	mock().expectNCalls(8, "on_ocpp_event").withParameter("event_type", OCPP_EVENT_MESSAGE_FREE);
 	for (int i = 0; i < 8; i++) {
-		LONGS_EQUAL(0, ocpp_push_request(OCPP_MSG_START_TRANSACTION, &start, sizeof(start), true));
+		LONGS_EQUAL(0, ocpp_push_request_force(OCPP_MSG_START_TRANSACTION, &start, sizeof(start), NULL));
 	}
-	LONGS_EQUAL(-ENOMEM, ocpp_push_request(OCPP_MSG_START_TRANSACTION, &start, sizeof(start), true));
+	LONGS_EQUAL(-ENOMEM, ocpp_push_request_force(OCPP_MSG_START_TRANSACTION, &start, sizeof(start), NULL));
 }
 
 TEST(Core, ShouldDropTransactionRelatedMessages_WhenServerReponsesWithErrorMoreThanMaxAttemptsConfigured) {
@@ -268,7 +268,7 @@ TEST(Core, ShouldDropTransactionRelatedMessages_WhenServerReponsesWithErrorMoreT
 		.type = OCPP_MSG_START_TRANSACTION,
 	};
 
-	ocpp_push_request(OCPP_MSG_START_TRANSACTION, &start, sizeof(start), true);
+	ocpp_push_request_force(OCPP_MSG_START_TRANSACTION, &start, sizeof(start), NULL);
 	mock().expectOneCall("ocpp_send").andReturnValue(0);
 	mock().expectOneCall("ocpp_recv").ignoreOtherParameters().andReturnValue(-ENOMSG);
 	step(0);
@@ -295,7 +295,7 @@ TEST(Core, ShouldSendTransactionRelatedmessagesIndefinitely_WhenTransportErrors)
 TEST(Core, ShouldDropNonTransactionRelatedMessagesAfterTimeout_WhenNoResponseReceived) {
 	ocpp_push_request(OCPP_MSG_DATA_TRANSFER, &(const struct ocpp_DataTransfer) {
 		.vendorId = "VendorID",
-	}, sizeof(struct ocpp_DataTransfer), false);
+	}, sizeof(struct ocpp_DataTransfer), NULL);
 
 	int i = 0;
 	for (; i < OCPP_DEFAULT_TX_RETRIES; i++) {
@@ -312,7 +312,7 @@ TEST(Core, ShouldDropNonTransactionRelatedMessagesAfterTimeout_WhenNoResponseRec
 TEST(Core, ShouldDropNonTransactionRelatedMessagesAfterTimeout_WhenTransportErrors) {
 	ocpp_push_request(OCPP_MSG_DATA_TRANSFER, &(const struct ocpp_DataTransfer) {
 		.vendorId = "VendorID",
-	}, sizeof(struct ocpp_DataTransfer), false);
+	}, sizeof(struct ocpp_DataTransfer), NULL);
 
 	int i = 0;
 	for (; i < OCPP_DEFAULT_TX_RETRIES-1; i++) {

--- a/tests/src/core_test.cpp
+++ b/tests/src/core_test.cpp
@@ -327,7 +327,7 @@ TEST(Core, ShouldDropNonTransactionRelatedMessagesAfterTimeout_WhenTransportErro
 	step(i*OCPP_DEFAULT_TX_TIMEOUT_SEC);
 }
 
-TEST(Core, t) {
+TEST(Core, ShouldSendBootNotification_WhenRequested) {
 	ocpp_send_bootnotification(&(const struct ocpp_BootNotification) {
 		.chargePointModel = "Model",
 		.chargePointVendor = "Vendor",
@@ -337,4 +337,25 @@ TEST(Core, t) {
 	mock().expectOneCall("ocpp_recv").ignoreOtherParameters().andReturnValue(-ENOMSG);
 	step(0);
 	check_tx(OCPP_MSG_ROLE_CALL, OCPP_MSG_BOOTNOTIFICATION);
+}
+
+TEST(Core, ShouldReturnNumberOfPendingMessages_WhenRequested) {
+	ocpp_push_request(OCPP_MSG_STATUS_NOTIFICATION, NULL, 0, NULL);
+	LONGS_EQUAL(1, ocpp_count_pending_requests());
+}
+
+TEST(Core, ShouldReturnTypeString_WhenValidTypeGiven) {
+	STRCMP_EQUAL("BootNotification", ocpp_stringify_type(OCPP_MSG_BOOTNOTIFICATION));
+}
+
+TEST(Core, ShouldReturnType_WhenValidTypeStringGiven) {
+	LONGS_EQUAL(OCPP_MSG_BOOTNOTIFICATION, ocpp_get_type_from_string("BootNotification"));
+}
+
+TEST(Core, ShouldReturnMSG_MAX_WhenInvalidTypeStringGiven) {
+	LONGS_EQUAL(OCPP_MSG_MAX, ocpp_get_type_from_string("UnknownType"));
+}
+
+TEST(Core, ShouldReturnMSG_MAX_WhenInvalidTypeIdGiven) {
+	LONGS_EQUAL(OCPP_MSG_MAX, ocpp_get_type_from_idstr("UnknownId"));
 }


### PR DESCRIPTION
This pull request includes significant changes to the OCPP module, focusing on enhancing the request handling mechanism and adding new stringify functions. The most important changes include the addition of a new function to forcefully push OCPP requests, modifications to the `ocpp_push_request` function, and the introduction of several new stringify functions.

Enhancements to request handling:

* [`include/ocpp/ocpp.h`](diffhunk://#diff-59599d08400ca1d5c8627ab5437efd2e7bad9f92704db37438e8e0f1d6640f41L83-R120): Added a new function `ocpp_push_request_force` to push OCPP request messages forcefully even if the queue is full. Modified the `ocpp_push_request` function to include an additional `created` parameter.
* [`src/ocpp.c`](diffhunk://#diff-eba7bf82e208cb35c2a746e48ef277383447b7724e6c53a58347fb0fcc88ac32L236-R237): Updated `push_message` function to handle the `created` parameter and integrated it into multiple functions, including `ocpp_push_request`, `ocpp_push_request_force`, `ocpp_push_request_defer`, and `ocpp_push_response`. [[1]](diffhunk://#diff-eba7bf82e208cb35c2a746e48ef277383447b7724e6c53a58347fb0fcc88ac32L236-R237) [[2]](diffhunk://#diff-eba7bf82e208cb35c2a746e48ef277383447b7724e6c53a58347fb0fcc88ac32R250-R253) [[3]](diffhunk://#diff-eba7bf82e208cb35c2a746e48ef277383447b7724e6c53a58347fb0fcc88ac32L691-R721) [[4]](diffhunk://#diff-eba7bf82e208cb35c2a746e48ef277383447b7724e6c53a58347fb0fcc88ac32L724-R742) [[5]](diffhunk://#diff-eba7bf82e208cb35c2a746e48ef277383447b7724e6c53a58347fb0fcc88ac32L739-R757)

New stringify functions:

* `include/ocpp/stringify.h` and `src/stringify.c`: Added new functions to stringify various OCPP status and reason codes, such as `ocpp_stringify_availability_status`, `ocpp_stringify_config_status`, `ocpp_stringify_data_status`, `ocpp_stringify_profile_status`, `ocpp_stringify_remote_status`, `ocpp_stringify_reservation_status`, `ocpp_stringify_trigger_status`, and `ocpp_stringify_stop_reason`. [[1]](diffhunk://#diff-559c85afde7ed634d7b68e22bdc168fe20eef39112057aa682043c63702bdeb6R19-R26) [[2]](diffhunk://#diff-ed5ad0e74f6a8b9365337a74f08bed038541dc8c51b3b023cd09e6cce1ec87f9R66-R165)

Key structure updates:

* [`include/ocpp/type.h`](diffhunk://#diff-6963ee29471e19305e768f2533479f081bf232d5b7138449b6c4b837b350ca07L383-R395): Updated the `ocpp_KeyValue` and `ocpp_idTagInfo` structures to use predefined constants for string lengths (`OCPP_CiString50`, `OCPP_CiString500`, `OCPP_CiString20`).

Test modifications:

* [`tests/src/core_test.cpp`](diffhunk://#diff-6b1943a70d29bb7eefa8a7ecd89c44c3b01214d6fb2d87c6308b66dac9317405L218-R223): Modified tests to use the new `ocpp_push_request_force` function and updated calls to `ocpp_push_request` to include the `created` parameter. [[1]](diffhunk://#diff-6b1943a70d29bb7eefa8a7ecd89c44c3b01214d6fb2d87c6308b66dac9317405L218-R223) [[2]](diffhunk://#diff-6b1943a70d29bb7eefa8a7ecd89c44c3b01214d6fb2d87c6308b66dac9317405L249-R255) [[3]](diffhunk://#diff-6b1943a70d29bb7eefa8a7ecd89c44c3b01214d6fb2d87c6308b66dac9317405L271-R271) [[4]](diffhunk://#diff-6b1943a70d29bb7eefa8a7ecd89c44c3b01214d6fb2d87c6308b66dac9317405L298-R298) [[5]](diffhunk://#diff-6b1943a70d29bb7eefa8a7ecd89c44c3b01214d6fb2d87c6308b66dac9317405L315-R315)