### PR TITLE
Add stringify functions for context and unit

### DIFF
--- a/include/ocpp/strconv.h
+++ b/include/ocpp/strconv.h
@@ -80,6 +80,9 @@ ocpp_measurand_t ocpp_get_measurand_from_string(const char *str,
 ocpp_auth_status_t ocpp_get_auth_status_from_string(const char *str);
 ocpp_boot_status_t ocpp_get_boot_status_from_string(const char *str);
 
+const char *ocpp_stringify_context(ocpp_reading_context_t ctx);
+const char *ocpp_stringify_unit(ocpp_measure_unit_t unit);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/strconv.c
+++ b/src/strconv.c
@@ -99,7 +99,8 @@ const char *ocpp_stringify_measurand(char *buf, const size_t bufsize,
 	return len? buf : NULL;
 }
 
-const char *ocpp_stringify_comm_status(ocpp_comm_status_t status) {
+const char *ocpp_stringify_comm_status(ocpp_comm_status_t status)
+{
 	const char *tbl[] = {
 		[OCPP_COMM_IDLE] = "Idle",
 		[OCPP_COMM_UPLOADED] = "Uploaded",
@@ -325,4 +326,46 @@ ocpp_boot_status_t ocpp_get_boot_status_from_string(const char *str)
 	} else {
 		return OCPP_BOOT_STATUS_UNKNOWN;
 	}
+}
+
+const char *ocpp_stringify_context(ocpp_reading_context_t ctx)
+{
+	const char *tbl[] = {
+		[OCPP_READ_CTX_UNKNOWN] = "Unknown",
+		[OCPP_READ_CTX_INT_BEGIN] = "Interruption.Begin",
+		[OCPP_READ_CTX_INT_END] = "Interruption.End",
+		[OCPP_READ_CTX_OTHER] = "Other",
+		[OCPP_READ_CTX_SAMPLE_CLOCK] = "Sample.Clock",
+		[OCPP_READ_CTX_SAMPLE_PERIODIC] = "Sample.Periodic",
+		[OCPP_READ_CTX_TRANSACTION_BEGIN] = "Transaction.Begin",
+		[OCPP_READ_CTX_TRANSACTION_END] = "Transaction.End",
+		[OCPP_READ_CTX_TRIGGER] = "Trigger",
+	};
+
+	return tbl[ctx];
+}
+
+const char *ocpp_stringify_unit(ocpp_measure_unit_t unit)
+{
+	const char *tbl[] = {
+		[OCPP_UNIT_UNKNOWN] = "Unknown",
+		[OCPP_UNIT_WH] = "Wh",
+		[OCPP_UNIT_KWH] = "kWh",
+		[OCPP_UNIT_VARH] = "varh",
+		[OCPP_UNIT_KVARH] = "kvarh",
+		[OCPP_UNIT_W] = "W",
+		[OCPP_UNIT_KW] = "kW",
+		[OCPP_UNIT_VA] = "VA",
+		[OCPP_UNIT_KVA] = "kVA",
+		[OCPP_UNIT_VAR] = "var",
+		[OCPP_UNIT_KVAR] = "kvar",
+		[OCPP_UNIT_A] = "A",
+		[OCPP_UNIT_V] = "V",
+		[OCPP_UNIT_CELSIUS] = "Celsius",
+		[OCPP_UNIT_FAHRENHEIT] = "Fahrenheit",
+		[OCPP_UNIT_K] = "K",
+		[OCPP_UNIT_PERCENT] = "Percent",
+	};
+
+	return tbl[unit];
 }


### PR DESCRIPTION
This pull request includes several changes to the `strconv` module in the OCPP project, focusing on adding new stringification functions and improving code formatting. The most important changes include the addition of new functions for converting enums to strings and a minor formatting update for consistency.

New stringification functions:

* [`include/ocpp/strconv.h`](diffhunk://#diff-4bc25cc36a83b80fabccdff51230b3aa115cac5eabe0ebb507fa11eb8cd1bf58R83-R85): Added declarations for `ocpp_stringify_context` and `ocpp_stringify_unit` functions.
* [`src/strconv.c`](diffhunk://#diff-3a4489bde10c99d1600d6a1a2b9a7e60625e998bf09d8a679f8504bf43a5eb38R330-R371): Implemented `ocpp_stringify_context` to convert `ocpp_reading_context_t` enums to their string representations.
* [`src/strconv.c`](diffhunk://#diff-3a4489bde10c99d1600d6a1a2b9a7e60625e998bf09d8a679f8504bf43a5eb38R330-R371): Implemented `ocpp_stringify_unit` to convert `ocpp_measure_unit_t` enums to their string representations.

Code formatting improvements:

* [`src/strconv.c`](diffhunk://#diff-3a4489bde10c99d1600d6a1a2b9a7e60625e998bf09d8a679f8504bf43a5eb38L102-R103): Updated the function definition of `ocpp_stringify_comm_status` to follow consistent formatting.