### PR TITLE
Add stringify function for configuration values

### DIFF
--- a/include/ocpp/core/configuration.h
+++ b/include/ocpp/core/configuration.h
@@ -25,24 +25,81 @@ typedef enum {
 	OCPP_CONF_TYPE_BOOL,
 } ocpp_configuration_data_t;
 
+/**
+ * @brief Checks if a configuration key exists.
+ *
+ * This function takes a configuration key as input and checks if the key
+ * exists in the configuration.
+ *
+ * @param[in] keystr The configuration key to be checked.
+ *
+ * @return true if the configuration key exists, false otherwise.
+ */
 bool ocpp_has_configuration(const char * const keystr);
+
 /**
  * @brief Count the number of configurations.
  *
  * @return the number of configurations.
  */
 size_t ocpp_count_configurations(void);
+
 /**
  * @brief Compute the total configuration size.
  *
  * @return the total configuration size.
  */
 size_t ocpp_compute_configuration_size(void);
+
+/**
+ * @brief Copies configuration data from a source buffer.
+ *
+ * This function copies configuration data from the provided source buffer
+ * into the internal configuration storage.
+ *
+ * @param[in] data The source buffer containing the configuration data.
+ * @param[in] datasize The size of the source buffer.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
 int ocpp_copy_configuration_from(const void *data, size_t datasize);
+
+/**
+ * @brief Copies configuration data to a destination buffer.
+ *
+ * This function copies the internal configuration data to the provided
+ * destination buffer.
+ *
+ * @param[out] buf The destination buffer where the configuration data will be
+ *             copied.
+ * @param[in] bufsize The size of the destination buffer.
+ *
+ * @return The number of bytes copied on success, or a negative error code on
+ *         failure.
+ */
 int ocpp_copy_configuration_to(void *buf, size_t bufsize);
+
+/**
+ * @brief Resets the configuration to its default values.
+ *
+ * This function resets all configuration settings to their default values.
+ */
 void ocpp_reset_configuration(void);
+
+/**
+ * @brief Sets a configuration value for a given key.
+ *
+ * This function sets the configuration value for the specified key.
+ *
+ * @param[in] keystr The configuration key to be set.
+ * @param[in] value The value to be set for the specified key.
+ * @param[in] value_size The size of the value.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
 int ocpp_set_configuration(const char * const keystr,
 		const void *value, size_t value_size);
+
 /**
  * @brief Get the configuration for the key string.
  *
@@ -55,14 +112,97 @@ int ocpp_set_configuration(const char * const keystr,
  */
 int ocpp_get_configuration(const char * const keystr,
 		void *buf, size_t bufsize, bool *readonly);
+
+/**
+ * @brief Retrieves the configuration value by index.
+ *
+ * This function retrieves the configuration value at the specified index.
+ * The result is stored in the provided buffer.
+ *
+ * @param[in] index The index of the configuration value to retrieve.
+ * @param[out] buf The buffer where the configuration value will be stored.
+ * @param[in] bufsize The size of the buffer.
+ * @param[out] readonly A pointer to a boolean that will be set to true if the
+ *             configuration is read-only.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
 int ocpp_get_configuration_by_index(int index,
 		void *buf, size_t bufsize, bool *readonly);
+
+/**
+ * @brief Checks if a configuration key is writable.
+ *
+ * This function checks if the specified configuration key is writable.
+ *
+ * @param[in] keystr The configuration key to check.
+ *
+ * @return true if the configuration key is writable, false otherwise.
+ */
 bool ocpp_is_configuration_writable(const char * const keystr);
+
+/**
+ * @brief Checks if a configuration key is readable.
+ *
+ * This function checks if the specified configuration key is readable.
+ *
+ * @param[in] keystr The configuration key to check.
+ *
+ * @return true if the configuration key is readable, false otherwise.
+ */
 bool ocpp_is_configuration_readable(const char * const keystr);
+
+/**
+ * @brief Gets the size of the configuration value for a given key.
+ *
+ * This function returns the size of the configuration value associated with the
+ * specified key.
+ *
+ * @param[in] keystr The configuration key to check.
+ *
+ * @return The size of the configuration value.
+ */
 size_t ocpp_get_configuration_size(const char * const keystr);
+
+/**
+ * @brief Gets the data type of the configuration value for a given key.
+ *
+ * This function returns the data type of the configuration value associated
+ * with the specified key.
+ *
+ * @param[in] keystr The configuration key to check.
+ *
+ * @return The data type of the configuration value.
+ */
 ocpp_configuration_data_t ocpp_get_configuration_data_type(
 		const char * const keystr);
+
+/**
+ * @brief Gets the configuration key string by index.
+ *
+ * This function returns the configuration key string at the specified index.
+ *
+ * @param[in] index The index of the configuration key string to retrieve.
+ * @return A pointer to the configuration key string.
+ */
 const char *ocpp_get_configuration_keystr_from_index(int index);
+
+/**
+ * @brief Converts a configuration key to its corresponding string value.
+ *
+ * This function takes a configuration key as input and finds the corresponding
+ * value. The value is then converted to a string and stored in the provided
+ * buffer. If the key does not exist, the function returns null.
+ *
+ * @param[in] keystr The configuration key to be converted.
+ * @param[out] buf The buffer where the resulting string value will be stored.
+ * @param[in] bufsize The size of the buffer.
+ *
+ * @return A pointer to the resulting string value, or null if the key does not
+ *         exist.
+ */
+const char *ocpp_stringify_configuration_value(const char *keystr,
+		char *buf, size_t bufsize);
 
 #if defined(__cplusplus)
 }

--- a/include/ocpp/strconv.h
+++ b/include/ocpp/strconv.h
@@ -13,42 +13,6 @@ extern "C" {
 
 #include "ocpp/type.h"
 
-/**
- * @brief Converts an ocpp_profile_t enum value to its string representation.
- *
- * This function takes an ocpp_profile_t enum value and converts it to a string
- * representation, storing the result in the provided buffer. The buffer size
- * should be sufficient to hold the resulting string. If the profile is not
- * valid, the function will return NULL.
- *
- * @param[out] buf The buffer to store the string representation.
- * @param[in] bufsize The size of the buffer.
- * @param[in] profile The ocpp_profile_t enum value to be converted.
- *
- * @return A pointer to the buffer containing the string representation, or NULL
- *         if the profile is not valid.
- */
-const char *ocpp_stringify_profile(char *buf, const size_t bufsize,
-		const ocpp_profile_t profile);
-
-/**
- * @brief Converts an ocpp_measurand_t enum value to its string representation.
- *
- * This function takes an ocpp_measurand_t enum value and converts it to a
- * string representation, storing the result in the provided buffer. The buffer
- * size should be sufficient to hold the resulting string. If the measurand is
- * not valid, the function will return NULL.
- *
- * @param[out] buf The buffer to store the string representation.
- * @param[in] bufsize The size of the buffer.
- * @param[in] measurand The ocpp_measurand_t enum value to be converted.
- *
- * @return A pointer to the buffer containing the string representation, or NULL
- *         if the measurand is not valid.
- */
-const char *ocpp_stringify_measurand(char *buf, const size_t bufsize,
-		const ocpp_measurand_t measurand);
-
 const char *ocpp_stringify_comm_status(ocpp_comm_status_t status);
 const char *ocpp_stringify_error(ocpp_error_t err);
 const char *ocpp_stringify_status(ocpp_status_t status);

--- a/include/ocpp/type.h
+++ b/include/ocpp/type.h
@@ -162,6 +162,7 @@ typedef enum {
 } ocpp_value_format_t;
 
 typedef enum {
+	OCPP_CHARGING_UNIT_NONE,
 	OCPP_CHARGING_UNIT_WATT,
 	OCPP_CHARGING_UNIT_AMPERE,
 } ocpp_charging_unit_t;

--- a/src/strconv.c
+++ b/src/strconv.c
@@ -6,98 +6,10 @@
 
 #include "ocpp/strconv.h"
 #include <string.h>
-#include <stdio.h>
 
 #if !defined(ARRAY_SIZE)
 #define ARRAY_SIZE(x)		(sizeof(x) / sizeof((x)[0]))
 #endif
-
-static size_t addstr_if(const int mask, const int value, const char *str,
-		char *buf, const size_t bufsize, bool comma)
-{
-	int len = 0;
-
-	if (mask & value) {
-		len = snprintf(buf, bufsize, "%s%s", comma? "," : "", str);
-	}
-
-	return len > 0? (size_t)len : 0;
-}
-
-const char *ocpp_stringify_profile(char *buf, const size_t bufsize,
-		const ocpp_profile_t profile)
-{
-	size_t len = 0;
-
-	len += addstr_if((int)profile, OCPP_PROFILE_CORE,
-			"Core", buf, bufsize, false);
-	len += addstr_if((int)profile, OCPP_PROFILE_FW_MGMT,
-			"FirmwareManagement", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)profile, OCPP_PROFILE_LOCAL_AUTH,
-			"LocalAuthListManagement",
-			&buf[len], bufsize - len, !!len);
-	len += addstr_if((int)profile, OCPP_PROFILE_RESERVATION,
-			"Reservation", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)profile, OCPP_PROFILE_SMART_CHARGING,
-			"SmartCharging", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)profile, OCPP_PROFILE_REMOTE_TRIGGER,
-			"RemoteTrigger", &buf[len], bufsize - len, !!len);
-
-	return len? buf : NULL;
-}
-
-const char *ocpp_stringify_measurand(char *buf, const size_t bufsize,
-		const ocpp_measurand_t measurand)
-{
-	size_t len = 0;
-
-	len += addstr_if((int)measurand, OCPP_MEASURAND_CURRENT_EXPORT,
-			"Current.Export", buf, bufsize, false);
-	len += addstr_if((int)measurand, OCPP_MEASURAND_CURRENT_IMPORT,
-			"Current.Import", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)measurand, OCPP_MEASURAND_CURRENT_OFFERED,
-			"Current.Offered", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)measurand, OCPP_MEASURAND_ENERGY_ACTIVE_EXPORT_REGISTER,
-			"Energy.Active.Export.Register", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)measurand, OCPP_MEASURAND_ENERGY_ACTIVE_IMPORT_REGISTER,
-			"Energy.Active.Import.Register", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)measurand, OCPP_MEASURAND_ENERGY_REACTIVE_EXPORT_REGISTER,
-			"Energy.Reactive.Export.Register", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)measurand, OCPP_MEASURAND_ENERGY_REACTIVE_IMPORT_REGISTER,
-			"Energy.Reactive.Import.Register", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)measurand, OCPP_MEASURAND_ENERGY_ACTIVE_EXPORT_INTERVAL,
-			"Energy.Active.Export.Interval", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)measurand, OCPP_MEASURAND_ENERGY_ACTIVE_IMPORT_INTERVAL,
-			"Energy.Active.Import.Interval", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)measurand, OCPP_MEASURAND_ENERGY_REACTIVE_EXPORT_INTERVAL,
-			"Energy.Reactive.Export.Interval", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)measurand, OCPP_MEASURAND_ENERGY_REACTIVE_IMPORT_INTERVAL,
-			"Energy.Reactive.Import.Interval", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)measurand, OCPP_MEASURAND_FREQUENCY,
-			"Frequency", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)measurand, OCPP_MEASURAND_POWER_ACTIVE_EXPORT,
-			"Power.Active.Export", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)measurand, OCPP_MEASURAND_POWER_ACTIVE_IMPORT,
-			"Power.Active.Import", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)measurand, OCPP_MEASURAND_POWER_FACTOR,
-			"Power.Factor", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)measurand, OCPP_MEASURAND_POWER_OFFERED,
-			"Power.Offered", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)measurand, OCPP_MEASURAND_POWER_REACTIVE_EXPORT,
-			"Power.Reactive.Export", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)measurand, OCPP_MEASURAND_POWER_REACTIVE_IMPORT,
-			"Power.Reactive.Import", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)measurand, OCPP_MEASURAND_RPM,
-			"RPM", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)measurand, OCPP_MEASURAND_SOC,
-			 "SoC", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)measurand, OCPP_MEASURAND_TEMPERATURE,
-			"Temperature", &buf[len], bufsize - len, !!len);
-	len += addstr_if((int)measurand, OCPP_MEASURAND_VOLTAGE,
-			"Voltage", &buf[len], bufsize - len, !!len);
-
-	return len? buf : NULL;
-}
 
 const char *ocpp_stringify_comm_status(ocpp_comm_status_t status)
 {

--- a/tests/src/configuration_test.cpp
+++ b/tests/src/configuration_test.cpp
@@ -124,3 +124,31 @@ TEST(Configuration, get_keystr_ShouldReturnKeyString_WhenKnownKeyGiven) {
 TEST(Configuration, get_keystr_ShouldReturnUnknownKeyString_WhenUnknownKeyGiven) {
 	STRCMP_EQUAL(NULL, ocpp_get_configuration_keystr_from_index(-1));
 }
+
+TEST(Configuration, ShouldReturnNull_WhenUnknownKeyGiven) {
+	char buf[32];
+	const char *y = ocpp_stringify_configuration_value("non-empty", buf, sizeof(buf));
+	STRCMP_EQUAL(NULL, y);
+}
+TEST(Configuration, ShouldReturnBooleanString_WhenBoolKeyGiven) {
+	char buf[32];
+	const char *y = ocpp_stringify_configuration_value("AllowOfflineTxForUnknownId", buf, sizeof(buf));
+	STRCMP_EQUAL("false", y);
+	y = ocpp_stringify_configuration_value("AuthorizeRemoteTxRequests", buf, sizeof(buf));
+	STRCMP_EQUAL("true", y);
+}
+TEST(Configuration, ShouldReturnIntString_WhenIntKeyGiven) {
+	char buf[32];
+	const char *y = ocpp_stringify_configuration_value("ConnectionTimeOut", buf, sizeof(buf));
+	STRCMP_EQUAL("180", y);
+}
+TEST(Configuration, ShouldReturnString_WhenStringKeyGiven) {
+	char buf[32];
+	const char *y = ocpp_stringify_configuration_value("CpoName", buf, sizeof(buf));
+	STRCMP_EQUAL("libmcu", y);
+}
+TEST(Configuration, ShouldReturnCSLString_WhenCSLKeyGiven) {
+	char buf[32];
+	const char *y = ocpp_stringify_configuration_value("MeterValuesAlignedData", buf, sizeof(buf));
+	STRCMP_EQUAL("Energy.Active.Import.Register", y);
+}

--- a/tests/src/strconv_test.cpp
+++ b/tests/src/strconv_test.cpp
@@ -12,48 +12,6 @@ TEST_GROUP(strconv) {
 	}
 };
 
-TEST(strconv, ShouldReturnProfileString_WhenCoreGiven) {
-	char buf[32];
-	const char *result = ocpp_stringify_profile(buf, sizeof(buf), OCPP_PROFILE_CORE);
-	STRCMP_EQUAL("Core", result);
-}
-
-TEST(strconv, ShouldReturnNull_WhenInvalidProfileGiven) {
-	char buf[32];
-	const char *result = ocpp_stringify_profile(buf, sizeof(buf), (ocpp_profile_t)0);
-	POINTERS_EQUAL(NULL, result);
-}
-
-TEST(strconv, ShouldReturnMultiProfileString_WhenMultiProfilesGiven) {
-	char buf[32];
-	const char *result = ocpp_stringify_profile(buf, sizeof(buf),
-			(ocpp_profile_t)(OCPP_PROFILE_CORE |
-				OCPP_PROFILE_REMOTE_TRIGGER |
-				OCPP_PROFILE_RESERVATION));
-	STRCMP_EQUAL("Core,Reservation,RemoteTrigger", result);
-}
-
-TEST(strconv, ShouldReturnMeasurandString_WhenMeasurandGiven) {
-	char buf[32];
-	const char *result = ocpp_stringify_measurand(buf, sizeof(buf), OCPP_MEASURAND_CURRENT_EXPORT);
-	STRCMP_EQUAL("Current.Export", result);
-}
-
-TEST(strconv, ShouldReturnNull_WhenInvalidMeasurandGiven) {
-	char buf[32];
-	const char *result = ocpp_stringify_measurand(buf, sizeof(buf), (ocpp_measurand_t)0);
-	POINTERS_EQUAL(NULL, result);
-}
-
-TEST(strconv, ShouldReturnMultiMeasurandString_WhenMultiMeasurandsGiven) {
-	char buf[64];
-	const char *result = ocpp_stringify_measurand(buf, sizeof(buf),
-			(ocpp_measurand_t)(OCPP_MEASURAND_CURRENT_EXPORT |
-				OCPP_MEASURAND_CURRENT_IMPORT |
-				OCPP_MEASURAND_ENERGY_ACTIVE_EXPORT_REGISTER));
-	STRCMP_EQUAL("Current.Export,Current.Import,Energy.Active.Export.Register", result);
-}
-
 TEST(strconv, ShouldReturnMeasurand_WhenFreqStringGiven) {
 	const ocpp_measurand_t y = ocpp_get_measurand_from_string("Frequency", 9);
 	LONGS_EQUAL(OCPP_MEASURAND_FREQUENCY, y);


### PR DESCRIPTION
This pull request includes several changes to the `ocpp` library, focusing on adding new functions for configuration management, updating the `typedef` enums, and enhancing the test coverage. The main changes include adding new functions to handle configuration data, removing redundant string conversion functions, and updating the tests accordingly.

### Configuration Management Enhancements:
* Added new functions to handle configuration data, such as `ocpp_copy_configuration_from`, `ocpp_copy_configuration_to`, `ocpp_set_configuration`, and `ocpp_stringify_configuration_value` in `include/ocpp/core/configuration.h` and `src/core/configuration.c`. [[1]](diffhunk://#diff-41ddabacc714c30356206f150e694ba9367895fbe74b96236dcaf41b0c4c432bR28-R102) [[2]](diffhunk://#diff-41ddabacc714c30356206f150e694ba9367895fbe74b96236dcaf41b0c4c432bR115-R206) [[3]](diffhunk://#diff-7b78f670a0b925cd7ffd1e8cfc27bf296bdfc4638f3377b9f590e2c1c50c685aR225-R411)
* Introduced `ocpp_has_configuration`, `ocpp_is_configuration_writable`, `ocpp_is_configuration_readable`, and `ocpp_get_configuration_size` functions to check configuration properties. [[1]](diffhunk://#diff-41ddabacc714c30356206f150e694ba9367895fbe74b96236dcaf41b0c4c432bR28-R102) [[2]](diffhunk://#diff-41ddabacc714c30356206f150e694ba9367895fbe74b96236dcaf41b0c4c432bR115-R206)

### Enum Updates:
* Added `OCPP_CHARGING_UNIT_NONE` to the `ocpp_charging_unit_t` enum in `include/ocpp/type.h`.

### Code Simplification:
* Removed redundant functions `ocpp_stringify_profile` and `ocpp_stringify_measurand` from `include/ocpp/strconv.h` and `src/strconv.c`. [[1]](diffhunk://#diff-4bc25cc36a83b80fabccdff51230b3aa115cac5eabe0ebb507fa11eb8cd1bf58L16-L51) [[2]](diffhunk://#diff-3a4489bde10c99d1600d6a1a2b9a7e60625e998bf09d8a679f8504bf43a5eb38L9-L101)

### Test Coverage:
* Added new tests for the `ocpp_stringify_configuration_value` function to verify its behavior with different key types in `tests/src/configuration_test.cpp`.
* Removed outdated tests related to the removed string conversion functions in `tests/src/strconv_test.cpp`.

### Miscellaneous:
* Defined `ARRAY_SIZE` macro in `src/core/configuration.c` for array size calculations.
* Included the `stdio.h` header in `src/core/configuration.c` for `snprintf` usage.