### PR TITLE
ci: add workflow to check version before release

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -1,0 +1,48 @@
+name: Check version.h before release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get latest tag
+        id: get_tag
+        run: |
+          TAG_VERSION=$(git describe --tags --always)
+          TAG_VERSION=${TAG_VERSION#v}
+          echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_ENV
+
+      - name: Extract version from version.h
+        id: get_header_version
+        run: |
+          HEADER_VERSION_STRING=$(grep -oP '(?<=#define OCPP_VERSION_STRING ")[^"]+' version.h)
+          HEADER_VERSION_MAJOR=$(grep -oP '(?<=#define OCPP_VERSION_MAJOR )\d+' version.h)
+          HEADER_VERSION_MINOR=$(grep -oP '(?<=#define OCPP_VERSION_MINOR )\d+' version.h)
+          HEADER_VERSION_BUILD=$(grep -oP '(?<=#define OCPP_VERSION_BUILD )\d+' version.h)
+
+          HEADER_VERSION="$HEADER_VERSION_MAJOR.$HEADER_VERSION_MINOR.$HEADER_VERSION_BUILD"
+
+          echo "Extracted header version: $HEADER_VERSION"
+          echo "HEADER_VERSION=$HEADER_VERSION" >> $GITHUB_ENV
+
+      - name: Compare versions
+        run: |
+          if [ "$TAG_VERSION" != "$HEADER_VERSION" ]; then
+            echo "::error:: version.h ($HEADER_VERSION) does not match git tag ($TAG_VERSION)"
+            exit 1
+          fi
+          echo "✅ Version match! Proceeding with release."
+
+      - name: Build & Release
+        run: |
+          echo "Now releasing version $TAG_VERSION..."

--- a/include/ocpp/version.h
+++ b/include/ocpp/version.h
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: 2024 권경환 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef LIBMCU_OCPP_VERSION_H
+#define LIBMCU_OCPP_VERSION_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#define OCPP_VERSION_STRING	"0.0.1"
+#define OCPP_VERSION_MAJOR	0
+#define OCPP_VERSION_MINOR	0
+#define OCPP_VERSION_BUILD	1
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* LIBMCU_OCPP_VERSION_H */


### PR DESCRIPTION
This pull request introduces a new workflow to check the version consistency before releasing and adds a new header file for version definitions.

### New workflow for version checking:

* [`.github/workflows/check-version.yml`](diffhunk://#diff-8afe568f7bca31f3457ff9b8e7fc829ac3918722cb3c77aa85b59c197b113664R1-R48): Added a GitHub Action workflow to check if the `version.h` file matches the git tag version before proceeding with the release. This includes steps for checking out the repository, extracting the version from `version.h`, and comparing it with the git tag.

### New version header file:

* [`include/ocpp/version.h`](diffhunk://#diff-924b84ae6a309b7412b8f2ae5ec2c200d7674e16f0770e965be0e91cd6724d4cR1-R23): Added a new header file defining version information, including `OCPP_VERSION_STRING`, `OCPP_VERSION_MAJOR`, `OCPP_VERSION_MINOR`, and `OCPP_VERSION_BUILD`.