### PR TITLE
Add ocpp_stringify_measurand function

### DIFF
--- a/include/ocpp/strconv.h
+++ b/include/ocpp/strconv.h
@@ -46,8 +46,7 @@ ocpp_boot_status_t ocpp_get_boot_status_from_string(const char *str);
 
 const char *ocpp_stringify_context(ocpp_reading_context_t ctx);
 const char *ocpp_stringify_unit(ocpp_measure_unit_t unit);
-const char *ocpp_stringify_measurand(char *buf, size_t bufsize,
-		ocpp_measurand_t measurand);
+const char *ocpp_stringify_measurand(ocpp_measurand_t measurand);
 
 #if defined(__cplusplus)
 }

--- a/include/ocpp/strconv.h
+++ b/include/ocpp/strconv.h
@@ -46,6 +46,8 @@ ocpp_boot_status_t ocpp_get_boot_status_from_string(const char *str);
 
 const char *ocpp_stringify_context(ocpp_reading_context_t ctx);
 const char *ocpp_stringify_unit(ocpp_measure_unit_t unit);
+const char *ocpp_stringify_measurand(char *buf, size_t bufsize,
+		ocpp_measurand_t measurand);
 
 #if defined(__cplusplus)
 }

--- a/src/strconv.c
+++ b/src/strconv.c
@@ -281,3 +281,34 @@ const char *ocpp_stringify_unit(ocpp_measure_unit_t unit)
 
 	return tbl[unit];
 }
+
+const char *ocpp_stringify_measurand(char *buf, size_t bufsize,
+		ocpp_measurand_t measurand)
+{
+	const char *tbl[] = {
+		"Current.Export",
+		"Current.Import",
+		"Current.Offered",
+		"Energy.Active.Export.Register",
+		"Energy.Active.Import.Register",
+		"Energy.Reactive.Export.Register",
+		"Energy.Reactive.Import.Register",
+		"Energy.Active.Export.Interval",
+		"Energy.Active.Import.Interval",
+		"Energy.Reactive.Export.Interval",
+		"Energy.Reactive.Import.Interval",
+		"Frequency",
+		"Power.Active.Export",
+		"Power.Active.Import",
+		"Power.Factor",
+		"Power.Offered",
+		"Power.Reactive.Export",
+		"Power.Reactive.Import",
+		"RPM",
+		"SoC",
+		"Temperature",
+		"Voltage",
+	};
+
+	return tbl[__builtin_ctz(measurand)];
+}

--- a/src/strconv.c
+++ b/src/strconv.c
@@ -282,8 +282,7 @@ const char *ocpp_stringify_unit(ocpp_measure_unit_t unit)
 	return tbl[unit];
 }
 
-const char *ocpp_stringify_measurand(char *buf, size_t bufsize,
-		ocpp_measurand_t measurand)
+const char *ocpp_stringify_measurand(ocpp_measurand_t measurand)
 {
 	const char *tbl[] = {
 		"Current.Export",

--- a/tests/src/strconv_test.cpp
+++ b/tests/src/strconv_test.cpp
@@ -81,3 +81,8 @@ TEST(strconv, ShouldReturnStopReasonString_WhenStopReasonGiven) {
 	const char *y = ocpp_stringify_stop_reason(OCPP_STOP_REASON_EMERGENCY_STOP);
 	STRCMP_EQUAL("EmergencyStop", y);
 }
+
+TEST(strconv, ShouldReturnMeasurandString_WhenMeasurandGiven) {
+	const char *y = ocpp_stringify_measurand(OCPP_MEASURAND_FREQUENCY);
+	STRCMP_EQUAL("Frequency", y);
+}


### PR DESCRIPTION
This pull request introduces a new function to convert `ocpp_measurand_t` values to their string representations. The changes are primarily focused on enhancing the `strconv` module by adding a new function and updating the corresponding header file.

Enhancements to `strconv` module:

* [`include/ocpp/strconv.h`](diffhunk://#diff-4bc25cc36a83b80fabccdff51230b3aa115cac5eabe0ebb507fa11eb8cd1bf58R49-R50): Added the declaration for the new function `ocpp_stringify_measurand` to convert `ocpp_measurand_t` values to string representations.
* [`src/strconv.c`](diffhunk://#diff-3a4489bde10c99d1600d6a1a2b9a7e60625e998bf09d8a679f8504bf43a5eb38R284-R314): Implemented the `ocpp_stringify_measurand` function, which uses a lookup table to return the string representation of `ocpp_measurand_t` values.