### PR TITLE
refactor: rename ARRAY_SIZE to ARRAY_COUNT for consistency

### DIFF
--- a/src/core/configuration.c
+++ b/src/core/configuration.c
@@ -18,8 +18,8 @@
 #define MIN(a, b)			(((a) > (b))? (b) : (a))
 #endif
 
-#if !defined(ARRAY_SIZE)
-#define ARRAY_SIZE(x)			(sizeof(x) / sizeof((x)[0]))
+#if !defined(ARRAY_COUNT)
+#define ARRAY_COUNT(x)			(sizeof(x) / sizeof((x)[0]))
 #endif
 
 #define CONF_SIZE(x)			(x)
@@ -353,7 +353,7 @@ static void stringify_csl(const configuration_t key,
 			stringify_charging_rate_unit },
 	};
 
-	for (size_t i = 0; i < ARRAY_SIZE(csl_handler); i++) {
+	for (size_t i = 0; i < ARRAY_COUNT(csl_handler); i++) {
 		if (key == csl_handler[i].key) {
 			csl_handler[i].fn(value, buf, bufsize);
 			break;

--- a/src/strconv.c
+++ b/src/strconv.c
@@ -7,8 +7,8 @@
 #include "ocpp/strconv.h"
 #include <string.h>
 
-#if !defined(ARRAY_SIZE)
-#define ARRAY_SIZE(x)		(sizeof(x) / sizeof((x)[0]))
+#if !defined(ARRAY_COUNT)
+#define ARRAY_COUNT(x)		(sizeof(x) / sizeof((x)[0]))
 #endif
 
 const char *ocpp_stringify_comm_status(ocpp_comm_status_t status)
@@ -201,7 +201,7 @@ ocpp_measurand_t ocpp_get_measurand_from_string(const char *str,
 		{ "Voltage", OCPP_MEASURAND_VOLTAGE },
 	};
 
-	for (size_t i = 0; i < ARRAY_SIZE(supported); i++) {
+	for (size_t i = 0; i < ARRAY_COUNT(supported); i++) {
 		if (strncmp(str, supported[i].str, len) == 0) {
 			return supported[i].code;
 		}


### PR DESCRIPTION
This pull request includes changes to update the macro definition for array size calculations across multiple files. The `ARRAY_SIZE` macro has been renamed to `ARRAY_COUNT` to improve code clarity and consistency.

Macro renaming:

* [`src/core/configuration.c`](diffhunk://#diff-7b78f670a0b925cd7ffd1e8cfc27bf296bdfc4638f3377b9f590e2c1c50c685aL21-R22): Changed the macro definition from `ARRAY_SIZE` to `ARRAY_COUNT` and updated its usage in the `stringify_csl` function. [[1]](diffhunk://#diff-7b78f670a0b925cd7ffd1e8cfc27bf296bdfc4638f3377b9f590e2c1c50c685aL21-R22) [[2]](diffhunk://#diff-7b78f670a0b925cd7ffd1e8cfc27bf296bdfc4638f3377b9f590e2c1c50c685aL356-R356)
* [`src/strconv.c`](diffhunk://#diff-3a4489bde10c99d1600d6a1a2b9a7e60625e998bf09d8a679f8504bf43a5eb38L10-R11): Updated the macro definition from `ARRAY_SIZE` to `ARRAY_COUNT` and modified its usage in the `ocpp_get_measurand_from_string` function. [[1]](diffhunk://#diff-3a4489bde10c99d1600d6a1a2b9a7e60625e998bf09d8a679f8504bf43a5eb38L10-R11) [[2]](diffhunk://#diff-3a4489bde10c99d1600d6a1a2b9a7e60625e998bf09d8a679f8504bf43a5eb38L204-R204)