### PR TITLE
feat: add user context retrieval by message ID

### DIFF
--- a/include/ocpp/ocpp.h
+++ b/include/ocpp/ocpp.h
@@ -51,6 +51,8 @@ struct ocpp_message {
 		} fmt;
 		size_t size;
 	} payload;
+
+	void *ctx;
 };
 
 /**
@@ -80,22 +82,22 @@ int ocpp_init(ocpp_event_callback_t cb, void *cb_ctx);
 int ocpp_step(void);
 
 /**
- * @brief Pushes an OCPP request message.
+ * @brief Pushes a new OCPP request message.
  *
- * This function creates and pushes an OCPP request message of the specified
- * type.
+ * This function pushes a new OCPP request message of the specified type with
+ * the given data. The user-defined context can be associated with the message
+ * for later retrieval.
  *
- * @param[in] type The type of the OCPP message to be pushed.
- * @param[in] data A pointer to the data to be included in the message.
- * @param[in] datasize The size of the data to be included in the message.
- * @param[out] created A pointer to a pointer to an ocpp_message structure
- *             where the created message will be stored.
+ * @param[in] type The type of the OCPP message.
+ * @param[in] data Pointer to the data to be included in the message.
+ * @param[in] datasize Size of the data in bytes.
+ * @param[in] ctx User-defined context to be associated with the message.
  *
  * @return Returns 0 if the request was successfully pushed, non-zero
  *         otherwise.
  */
-int ocpp_push_request(ocpp_message_t type, const void *data, size_t datasize,
-		struct ocpp_message **created);
+int ocpp_push_request(ocpp_message_t type,
+		const void *data, size_t datasize, void *ctx);
 
 /**
  * @brief Pushes an OCPP request message forcefully.
@@ -110,14 +112,13 @@ int ocpp_push_request(ocpp_message_t type, const void *data, size_t datasize,
  * @param[in] type The type of the OCPP message to be pushed.
  * @param[in] data A pointer to the data to be included in the message.
  * @param[in] datasize The size of the data to be included in the message.
- * @param[out] created A pointer to a pointer to an ocpp_message structure
- *             where the created message will be stored.
+ * @param[in] ctx User-defined context to be associated with the message.
  *
  * @return Returns 0 if the request was successfully pushed, non-zero
  *         otherwise.
  */
 int ocpp_push_request_force(ocpp_message_t type, const void *data,
-		size_t datasize, struct ocpp_message **created);
+		size_t datasize, void *ctx);
 
 /**
  * @brief Pushes a deferred OCPP request.
@@ -130,11 +131,12 @@ int ocpp_push_request_force(ocpp_message_t type, const void *data,
  * @param[in] datasize Size of the data in bytes.
  * @param[in] timer_sec The timer duration in seconds after which the request
  *            will be processed.
+ * @param[in] ctx User-defined context to be associated with the message.
  *
  * @return 0 on success, or a negative error code on failure.
  */
-int ocpp_push_request_defer(ocpp_message_t type,
-		const void *data, size_t datasize, uint32_t timer_sec);
+int ocpp_push_request_defer(ocpp_message_t type, const void *data,
+		size_t datasize, uint32_t timer_sec, void *ctx);
 
 /**
  * @brief Pushes an OCPP response.
@@ -147,11 +149,26 @@ int ocpp_push_request_defer(ocpp_message_t type,
  * @param[in] datasize Size of the data in bytes.
  * @param[in] err Boolean flag indicating if the response is an error (true) or
  *            not (false).
+ * @param[in] ctx User-defined context to be associated with the message.
  *
  * @return 0 on success, or a negative error code on failure.
  */
 int ocpp_push_response(const struct ocpp_message *req,
-		const void *data, size_t datasize, bool err);
+		const void *data, size_t datasize, bool err, void *ctx);
+
+/**
+ * @brief Retrieves an OCPP message by its ID.
+ *
+ * This function searches for and returns a pointer to the OCPP message
+ * that matches the given message ID.
+ *
+ * @param id The ID of the message to retrieve.
+ *
+ * @return struct ocpp_message* Pointer to the OCPP message if found, otherwise
+ *         NULL.
+ */
+struct ocpp_message *
+ocpp_get_message_by_id(const char id[OCPP_MESSAGE_ID_MAXLEN]);
 
 /**
  * @brief Counts the number of pending OCPP requests.

--- a/include/ocpp_configuration.def.template
+++ b/include/ocpp_configuration.def.template
@@ -45,7 +45,7 @@ OCPP_CONFIG(ReserveConnectorZeroSupported,	R,	BOOL,		false)
 
 /* Smart Charging Profile */
 OCPP_CONFIG(ChargeProfileMaxStackLevel,		R,	INT,		0)
-OCPP_CONFIG(ChargingScheduleAllowedChargingRateUnit,	R,	CSL,		0)
+OCPP_CONFIG(ChargingScheduleAllowedChargingRateUnit,	R,	CSL,	0)
 OCPP_CONFIG(ChargingScheduleMaxPeriods,		R,	INT,		0)
 OCPP_CONFIG(ConnectorSwitch3to1PhaseSupported,	R,	BOOL,		false)
 OCPP_CONFIG(MaxChargingProfilesInstalled,	R,	INT,		0)

--- a/tests/src/core_test.cpp
+++ b/tests/src/core_test.cpp
@@ -370,3 +370,20 @@ TEST(Core, ShouldReturnMSG_MAX_WhenInvalidTypeStringGiven) {
 TEST(Core, ShouldReturnMSG_MAX_WhenInvalidTypeIdGiven) {
 	LONGS_EQUAL(OCPP_MSG_MAX, ocpp_get_type_from_idstr("UnknownId"));
 }
+
+TEST(Core, ShouldReturnMessage_WhenMatchingMessageIdGiven) {
+	ocpp_push_request(OCPP_MSG_STATUS_NOTIFICATION, NULL, 0, NULL);
+	mock().expectOneCall("ocpp_send").andReturnValue(0);
+	mock().expectOneCall("ocpp_recv").ignoreOtherParameters().andReturnValue(-ENOMSG);
+	step(0);
+
+	const uint8_t *id = (const uint8_t *)sent.message_id;
+	struct ocpp_message *msg = ocpp_get_message_by_id((const char *)id);
+	CHECK(msg != NULL);
+	STRCMP_EQUAL((const char *)id, msg->id);
+}
+
+TEST(Core, ShouldReturnNull_WhenNoMatchingMessageIdFound) {
+	struct ocpp_message *msg = ocpp_get_message_by_id("UnknownId");
+	POINTERS_EQUAL(NULL, msg);
+}


### PR DESCRIPTION
This pull request introduces several changes to the OCPP (Open Charge Point Protocol) module, mainly focusing on adding user-defined context to various functions and improving message handling. Here are the most important changes:

### Enhancements to OCPP message handling:

* Added a `ctx` field to the `ocpp_message` structure to store user-defined context. (`include/ocpp/ocpp.h`)
* Modified the `ocpp_push_request`, `ocpp_push_request_force`, `ocpp_push_request_defer`, and `ocpp_push_response` functions to include a `ctx` parameter for user-defined context. (`include/ocpp/ocpp.h`) [[1]](diffhunk://#diff-59599d08400ca1d5c8627ab5437efd2e7bad9f92704db37438e8e0f1d6640f41L83-R100) [[2]](diffhunk://#diff-59599d08400ca1d5c8627ab5437efd2e7bad9f92704db37438e8e0f1d6640f41L113-R121) [[3]](diffhunk://#diff-59599d08400ca1d5c8627ab5437efd2e7bad9f92704db37438e8e0f1d6640f41R134-R139) [[4]](diffhunk://#diff-59599d08400ca1d5c8627ab5437efd2e7bad9f92704db37438e8e0f1d6640f41R152-R171)

### Code improvements:

* Replaced `memcmp` with `strcmp` for comparing message IDs in the `find_msg_by_idstr` function to simplify the comparison logic. (`src/ocpp.c`)
* Updated the `push_message` function to handle the `ctx` parameter and removed the `created` output parameter. (`src/ocpp.c`) [[1]](diffhunk://#diff-eba7bf82e208cb35c2a746e48ef277383447b7724e6c53a58347fb0fcc88ac32L236-R236) [[2]](diffhunk://#diff-eba7bf82e208cb35c2a746e48ef277383447b7724e6c53a58347fb0fcc88ac32R246-L253)

### New functionality:

* Added a new function `ocpp_get_message_by_id` to retrieve an OCPP message by its ID. (`include/ocpp/ocpp.h`, `src/ocpp.c`) [[1]](diffhunk://#diff-59599d08400ca1d5c8627ab5437efd2e7bad9f92704db37438e8e0f1d6640f41R152-R171) [[2]](diffhunk://#diff-eba7bf82e208cb35c2a746e48ef277383447b7724e6c53a58347fb0fcc88ac32L742-R779)