### PR TITLE
fix: replace zero-length arrays with flexible array members

### DIFF
--- a/include/ocpp/core/messages.h
+++ b/include/ocpp/core/messages.h
@@ -70,16 +70,17 @@ struct ocpp_DataTransfer {
 	char vendorId[OCPP_CiString255]; /* required */
 	char messageId[OCPP_CiString50];
 	char padding[13];
-	char data[0];
+	char data[];
 };
 
 struct ocpp_DataTransfer_conf {
 	ocpp_data_status_t status;
-	char data[0];
+	char data[];
 };
 
 struct ocpp_GetConfiguration {
-	char keys[0];
+	char dummy;
+	char keys[];
 };
 
 struct ocpp_GetConfiguration_conf {
@@ -98,7 +99,7 @@ struct ocpp_Heartbeat_conf {
 struct ocpp_MeterValues {
 	int connectorId;
 	int transactionId;
-	struct ocpp_MeterValue meterValue;
+	uint8_t meterValue[]; /* struct ocpp_MeterValue */
 };
 
 struct ocpp_MeterValues_conf {
@@ -108,7 +109,7 @@ struct ocpp_MeterValues_conf {
 struct ocpp_RemoteStartTransaction {
 	int connectorId;
 	char idTag[OCPP_CiString20];
-	struct ocpp_ChargingProfile chargingProfile;
+	uint8_t chargingProfile[]; /* struct ocpp_ChargingProfile */
 };
 
 struct ocpp_RemoteStartTransaction_conf {
@@ -164,7 +165,7 @@ struct ocpp_StopTransaction {
 	time_t timestamp;
 	int transactionId;
 	ocpp_stop_reason_t reason;
-	struct ocpp_MeterValue transactionData;
+	uint8_t meterValue[]; /* struct ocpp_MeterValue */
 };
 
 struct ocpp_StopTransaction_conf {

--- a/include/ocpp/sc/messages.h
+++ b/include/ocpp/sc/messages.h
@@ -31,12 +31,12 @@ struct ocpp_GetCompositeSchedule_conf {
 	ocpp_profile_status_t status;
 	int connectorId;
 	time_t scheduleStart;
-	struct ocpp_ChargingSchedule chargingSchedule;
+	uint8_t chargingSchedule[]; /* struct ocpp_ChargingSchedule */
 };
 
 struct ocpp_SetChargingProfile {
 	int connectorId;
-	struct ocpp_ChargingProfile csChargingProfiles;
+	uint8_t csChargingProfiles[]; /* struct ocpp_ChargingProfile */
 };
 
 struct ocpp_SetChargingProfile_conf {

--- a/include/ocpp/security/messages.h
+++ b/include/ocpp/security/messages.h
@@ -80,7 +80,8 @@ struct ocpp_CertificateHashData {
 };
 
 struct ocpp_CertificateSigned {
-	char certificateChain[0];
+	char dummy;
+	char certificateChain[];
 };
 
 struct ocpp_CertificateSigned_conf {
@@ -116,7 +117,7 @@ struct ocpp_GetInstalledCertificateIds_conf {
 struct ocpp_LogParameters {
 	time_t oldestTimestamp;
 	time_t latestTimestamp;
-	char remoteLocation[0];
+	char remoteLocation[];
 };
 
 struct ocpp_GetLog {
@@ -124,17 +125,17 @@ struct ocpp_GetLog {
 	int requestId;
 	int retries;
 	int retryInterval;
-	struct ocpp_LogParameters log;
+	uint8_t log[];
 };
 
 struct ocpp_GetLog_conf {
 	ocpp_security_status_t status;
-	char filename[0];
+	char filename[];
 };
 
 struct ocpp_InstallCertificate {
 	ocpp_security_cert_t certificateType;
-	char certificate[0];
+	char certificate[];
 };
 
 struct ocpp_InstallCertificate_conf {
@@ -153,7 +154,7 @@ struct ocpp_LogStatusNotification_conf {
 struct ocpp_SecurityEventNotification {
 	ocpp_security_event_t type;
 	time_t timestamp;
-	char techInfo[0];
+	char techInfo[];
 };
 
 struct ocpp_SecurityEventNotification_conf {
@@ -161,7 +162,8 @@ struct ocpp_SecurityEventNotification_conf {
 };
 
 struct ocpp_SignCertificate {
-	char csr[0];
+	char dummy;
+	char csr[];
 };
 
 struct ocpp_SignCertificate_conf {

--- a/include/ocpp/type.h
+++ b/include/ocpp/type.h
@@ -11,6 +11,7 @@
 extern "C" {
 #endif
 
+#include <stdint.h>
 #include <stdbool.h>
 #include <time.h>
 
@@ -410,7 +411,7 @@ struct ocpp_ChargingSchedule {
 	ocpp_charging_unit_t chargingRateUnit;
 	int minChargingRate_tenth;
 	int nr_chargingSchedulePeriod;
-	struct ocpp_ChargingSchedulePeriod chargingSchedulePeriod[0];
+	uint8_t chargingSchedulePeriod[]; /* struct ocpp_ChargingSchedulePeriod */
 };
 
 struct ocpp_ChargingProfile {
@@ -422,7 +423,7 @@ struct ocpp_ChargingProfile {
 	ocpp_charging_profile_recurrency_t recurrencyKind;
 	time_t validFrom;
 	time_t validTo;
-	struct ocpp_ChargingSchedule chargingSchedule;
+	uint8_t chargingSchedule[]; /* struct ocpp_ChargingSchedule */
 };
 
 struct ocpp_SampledValue {
@@ -437,7 +438,8 @@ struct ocpp_SampledValue {
 
 struct ocpp_MeterValue {
 	time_t timestamp;
-	struct ocpp_SampledValue sampledValue[0];
+	size_t nr_sampledValue;
+	uint8_t sampledValue[]; /* struct ocpp_SampledValue */
 };
 
 #if defined(__cplusplus)

--- a/src/core/configuration.c
+++ b/src/core/configuration.c
@@ -99,7 +99,7 @@ static void link_configuration_pool(void)
 {
 	size_t cidx = 0;
 
-	for (configuration_t i = 0; i < CONFIGURATION_MAX; i++) {
+	for (uint32_t i = 0; i < CONFIGURATION_MAX; i++) {
 		configurations[i].value = &configurations_pool[cidx];
 		cidx += get_value_cap(i);
 	}

--- a/src/ocpp.c
+++ b/src/ocpp.c
@@ -323,6 +323,7 @@ static bool should_send_heartbeat(const time_t *now)
 /* Retry interval for the message that is not delivered to the server. */
 static time_t get_retry_interval(const struct message *msg, const time_t *now)
 {
+	(void)msg;
 	uint32_t interval = OCPP_DEFAULT_TX_TIMEOUT_SEC;
 	return *now + interval;
 }
@@ -469,12 +470,15 @@ static int process_timer_messages(const time_t *now)
 
 static void process_central_request(const struct ocpp_message *received)
 {
+	(void)received;
 	OCPP_INFO("rx: %s.req", ocpp_stringify_type(received->type));
 }
 
 static bool process_central_response_error(const struct ocpp_message *received,
 		struct message *req, const time_t *now)
 {
+	(void)received;
+
 	if (!is_transaction_related(req)) {
 		return true;
 	}
@@ -488,9 +492,10 @@ static bool process_central_response_error(const struct ocpp_message *received,
 		update_message_expiry(req, now);
 		put_msg_wait(req);
 
-		OCPP_INFO("%s will be sent again at %ld (%d/%d)",
+		OCPP_INFO("%s will be sent again at %lu (%d/%d)",
 				ocpp_stringify_type(req->body.type),
-				req->expiry, req->attempts, max_attempts);
+				(unsigned long)req->expiry,
+				req->attempts, max_attempts);
 		return false;
 	}
 
@@ -500,6 +505,9 @@ static bool process_central_response_error(const struct ocpp_message *received,
 static bool process_central_response_result(const struct ocpp_message *received,
 		struct message *req, const time_t *now)
 {
+	(void)req;
+	(void)now;
+
 	if (received->type == OCPP_MSG_BOOTNOTIFICATION) {
 		const struct ocpp_BootNotification_conf *p =
 			(const struct ocpp_BootNotification_conf *)
@@ -670,9 +678,9 @@ ocpp_message_t ocpp_get_type_from_string(const char *typestr)
 {
 	const char **msgstr = get_typestr_array();
 
-	for (ocpp_message_t i = 0; i < OCPP_MSG_MAX; i++) {
+	for (uint32_t i = 0; i < OCPP_MSG_MAX; i++) {
 		if (strcmp(typestr, msgstr[i]) == 0) {
-			return i;
+			return (ocpp_message_t)i;
 		}
 	}
 


### PR DESCRIPTION
This pull request includes multiple changes to improve the handling of flexible array members in various structures and to enhance code safety and readability by addressing potential issues with data types and unused parameters.

### Improvements to flexible array members:

* [`include/ocpp/core/messages.h`](diffhunk://#diff-0771c0b9f339b0551ea0ff95d081fb57869a709c1a4c2174e0de9e688d31f80dL73-R83): Changed the definition of flexible array members from `char data[0]` to `char data[]` in multiple structures to comply with modern C standards. [[1]](diffhunk://#diff-0771c0b9f339b0551ea0ff95d081fb57869a709c1a4c2174e0de9e688d31f80dL73-R83) [[2]](diffhunk://#diff-0771c0b9f339b0551ea0ff95d081fb57869a709c1a4c2174e0de9e688d31f80dL101-R102) [[3]](diffhunk://#diff-0771c0b9f339b0551ea0ff95d081fb57869a709c1a4c2174e0de9e688d31f80dL111-R112) [[4]](diffhunk://#diff-0771c0b9f339b0551ea0ff95d081fb57869a709c1a4c2174e0de9e688d31f80dL167-R168)
* [`include/ocpp/sc/messages.h`](diffhunk://#diff-793a584bb3ca07c1f13622042ec77f1dc0ead3806eefe562b568111026916669L34-R39): Updated flexible array members to use `uint8_t` arrays with comments indicating the intended struct types.
* [`include/ocpp/security/messages.h`](diffhunk://#diff-dc79a739e70cf6ac271df1c16fda394c394338807df035393adfacfe909b5577L83-R84): Replaced zero-length arrays with flexible array members and added dummy members where necessary. [[1]](diffhunk://#diff-dc79a739e70cf6ac271df1c16fda394c394338807df035393adfacfe909b5577L83-R84) [[2]](diffhunk://#diff-dc79a739e70cf6ac271df1c16fda394c394338807df035393adfacfe909b5577L119-R138) [[3]](diffhunk://#diff-dc79a739e70cf6ac271df1c16fda394c394338807df035393adfacfe909b5577L156-R166)
* [`include/ocpp/type.h`](diffhunk://#diff-6963ee29471e19305e768f2533479f081bf232d5b7138449b6c4b837b350ca07L413-R413): Updated flexible array members to use `uint8_t` arrays with comments indicating the intended struct types and added size fields where necessary. [[1]](diffhunk://#diff-6963ee29471e19305e768f2533479f081bf232d5b7138449b6c4b837b350ca07L413-R413) [[2]](diffhunk://#diff-6963ee29471e19305e768f2533479f081bf232d5b7138449b6c4b837b350ca07L425-R425) [[3]](diffhunk://#diff-6963ee29471e19305e768f2533479f081bf232d5b7138449b6c4b837b350ca07L440-R441)

### Code safety and readability enhancements:

* [`src/core/configuration.c`](diffhunk://#diff-7b78f670a0b925cd7ffd1e8cfc27bf296bdfc4638f3377b9f590e2c1c50c685aL102-R102): Changed loop variable type from `configuration_t` to `uint32_t` for better type safety.
* [`src/ocpp.c`](diffhunk://#diff-eba7bf82e208cb35c2a746e48ef277383447b7724e6c53a58347fb0fcc88ac32R326): Added `(void)` casts to unused function parameters to avoid compiler warnings and improved the logging format to use `unsigned long` for time values. [[1]](diffhunk://#diff-eba7bf82e208cb35c2a746e48ef277383447b7724e6c53a58347fb0fcc88ac32R326) [[2]](diffhunk://#diff-eba7bf82e208cb35c2a746e48ef277383447b7724e6c53a58347fb0fcc88ac32R473-R481) [[3]](diffhunk://#diff-eba7bf82e208cb35c2a746e48ef277383447b7724e6c53a58347fb0fcc88ac32L491-R498) [[4]](diffhunk://#diff-eba7bf82e208cb35c2a746e48ef277383447b7724e6c53a58347fb0fcc88ac32R508-R510) [[5]](diffhunk://#diff-eba7bf82e208cb35c2a746e48ef277383447b7724e6c53a58347fb0fcc88ac32L673-R683)