### PR TITLE
feat(ocpp): support unlimited retries for message sending

### DIFF
--- a/include/ocpp/ocpp.h
+++ b/include/ocpp/ocpp.h
@@ -24,6 +24,15 @@ extern "C" {
 #include "ocpp/overrides.h"
 #include "ocpp/backend.h"
 
+/* If a response is received from the server, operate as defined in the
+ * specification (drop immediately if it is not a transaction-related message).
+ * If no response is received from the server, retry sending the message up to
+ * `OCPP_DEFAULT_TX_RETRIES` times before discarding it. If set to 0, retry
+ * indefinitely. */
+#if !defined(OCPP_DEFAULT_TX_RETRIES)
+#define OCPP_DEFAULT_TX_RETRIES			0
+#endif
+
 #if !defined(OCPP_DEFAULT_TX_TIMEOUT_SEC)
 #define OCPP_DEFAULT_TX_TIMEOUT_SEC		10
 #endif

--- a/src/ocpp.c
+++ b/src/ocpp.c
@@ -24,10 +24,6 @@
 #define OCPP_ERROR(...)
 #endif
 
-#if !defined(OCPP_DEFAULT_TX_RETRIES)
-#define OCPP_DEFAULT_TX_RETRIES			3
-#endif
-
 #define container_of(ptr, type, member)		\
 	((type *)(void *)((char *)(ptr) - offsetof(type, member)))
 
@@ -401,7 +397,8 @@ static bool should_drop(struct message *msg)
 {
 	const uint32_t max_attempts = OCPP_DEFAULT_TX_RETRIES;
 
-	if (!is_droppable(msg) || msg->attempts < max_attempts) {
+	if (!is_droppable(msg) || !max_attempts ||
+			msg->attempts < max_attempts) {
 		return false;
 	}
 
@@ -464,20 +461,23 @@ static void send_message(struct message *msg, const time_t *now)
 
 	del_msg_ready(msg);
 
+	const struct ocpp_backend_message_header *h = &msg->body.data.header;
+
 	OCPP_INFO("tx: %s.req (%d/%d) waiting up to %lu seconds",
-			ocpp_stringify_type(msg->body.data.header.type),
+			ocpp_stringify_type(h->type),
 			msg->attempts, OCPP_DEFAULT_TX_RETRIES,
 			(unsigned long)(msg->expiry - *now));
 
 	if (ocpp_send(&msg->body) == 0) {
-		if (msg->body.data.header.role == OCPP_MSG_ROLE_CALL) {
+		if (h->role == OCPP_MSG_ROLE_CALL) {
 			put_msg_wait(msg);
 			return;
 		}
 	} else {
-		if (msg->body.data.header.type == OCPP_MSG_BOOTNOTIFICATION ||
-				msg->attempts < OCPP_DEFAULT_TX_RETRIES ||
-				is_transaction_related(msg)) {
+		if (OCPP_DEFAULT_TX_RETRIES == 0 ||
+				is_transaction_related(msg) ||
+				h->type == OCPP_MSG_BOOTNOTIFICATION ||
+				msg->attempts < OCPP_DEFAULT_TX_RETRIES) {
 			put_msg_wait(msg);
 			return;
 		}


### PR DESCRIPTION
This pull request updates how message retry attempts are handled in the OCPP implementation, making retry logic more flexible and configurable. The main change is to allow indefinite retries when `OCPP_DEFAULT_TX_RETRIES` is set to 0, and to clarify the behavior for transaction-related messages and server responses.

Retry logic improvements:

* Changed the default value of `OCPP_DEFAULT_TX_RETRIES` from 3 to 0 in `include/ocpp/ocpp.h`, and documented that setting it to 0 enables indefinite retries. [[1]](diffhunk://#diff-59599d08400ca1d5c8627ab5437efd2e7bad9f92704db37438e8e0f1d6640f41R27-R35) [[2]](diffhunk://#diff-eba7bf82e208cb35c2a746e48ef277383447b7724e6c53a58347fb0fcc88ac32L27-L30)
* Updated the message dropping logic in `should_drop` to never drop messages if retries are set to 0 (indefinite), or if the message has not exceeded the retry limit.
* Modified the message sending logic in `send_message` to ensure transaction-related messages and messages with indefinite retries are always retried, and clarified the conditions for retrying and dropping messages.